### PR TITLE
CSC-6870 Update build mechanism of office365-rest-client library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .vscode/*
 .venv
 .DS_Store
+*.egg-info
+build/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded ignore rules to exclude common packaging metadata and build artifacts, keeping repositories cleaner and preventing accidental commits of generated files.
  * Added a standardized Python build configuration using setuptools and wheel (PEP 517/518), enabling consistent, reproducible distribution builds across environments.
  * These changes improve developer workflow and packaging reliability without affecting application behavior or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->